### PR TITLE
Adds setup for required CUDA-enabled PyTorch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 
+env/
+.env/
+venv/
+.venv/
+
 __pycache__/
 
 data/cartpole/data/

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ You can instantly run the demo:
    ```
  - Install requirements
    ```
-   pip3 install -r requirements.txt
+   pip3 install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
    pip3 install tensorflow-gpu tensorflow_addons
    ```
  - Run inference:
@@ -83,7 +83,7 @@ cd GANTheftAuto
 ```
 - Install dependencies
 ```
-pip3 install -r requirements.txt
+pip3 install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
 ```
 
 ## Dataset extraction

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-torch
+torch==1.9.0+cu102
 opencv-python
-torchvision
+torchvision==0.10.0+cu102
 tensorboardX
 opencv-python
 numpy
 keyboard
+pandas


### PR DESCRIPTION
First off, this is such a cool project. Thank you so much for sharing your work and including a pre-trained model to demonstrate!

This PR addresses issue #4 by installing the correct version of PyTorch via the requirements.txt, and updates the readme to reflect the required link. Installing torch as currently configured defaults to the CPU platform which is not supported by the demo model.

Secondly, this addresses another error I encountered after this one where pandas was not installed as currently documented - a requirement of keras (which as you know underlies TF). Since TF is only required for the demo as it stands, you could simply include this in the readme instead. I'll defer to the maintainers on your desired approach.

```
Traceback (most recent call last):
  File "C:\Users\kimba\Code\misc\GANTheftAuto\inference.py", line 273, in <module>
    inference(opts.gpu, opts)
  File "C:\Users\kimba\Code\misc\GANTheftAuto\inference.py", line 166, in inference
    upsampled_img = upsample.inference(np.rollaxis(prev_state[0].cpu().numpy(), 0, 3))
  File "C:\Users\kimba\Code\misc\GANTheftAuto\upsample\upsample.py", line 17, in inference
    upsampled = model.predict(np.expand_dims(img, axis=0))
  File "C:\Users\kimba\Code\misc\GANTheftAuto\venv\lib\site-packages\tensorflow\python\keras\engine\training.py", line 1696, in predict
    data_handler = data_adapter.get_data_handler(
  File "C:\Users\kimba\Code\misc\GANTheftAuto\venv\lib\site-packages\tensorflow\python\keras\engine\data_adapter.py", line 1364, in get_data_handler
    return DataHandler(*args, **kwargs)
  File "C:\Users\kimba\Code\misc\GANTheftAuto\venv\lib\site-packages\tensorflow\python\keras\engine\data_adapter.py", line 1152, in __init__
    adapter_cls = select_data_adapter(x, y)
  File "C:\Users\kimba\Code\misc\GANTheftAuto\venv\lib\site-packages\tensorflow\python\keras\engine\data_adapter.py", line 988, in select_data_adapter
    adapter_cls = [cls for cls in ALL_ADAPTER_CLS if cls.can_handle(x, y)]
  File "C:\Users\kimba\Code\misc\GANTheftAuto\venv\lib\site-packages\tensorflow\python\keras\engine\data_adapter.py", line 988, in <listcomp>
    adapter_cls = [cls for cls in ALL_ADAPTER_CLS if cls.can_handle(x, y)]
  File "C:\Users\kimba\Code\misc\GANTheftAuto\venv\lib\site-packages\tensorflow\python\keras\engine\data_adapter.py", line 227, in can_handle
    tensor_types = _get_tensor_types()
  File "C:\Users\kimba\Code\misc\GANTheftAuto\venv\lib\site-packages\tensorflow\python\keras\engine\data_adapter.py", line 1637, in _get_tensor_types
    return (ops.Tensor, np.ndarray, pd.Series, pd.DataFrame)
AttributeError: module 'pandas' has no attribute 'Series'
```

Finally, I've ammended the gitignore to exclude the most common names for virtual environment directories, since this is how I (and presumably many others) set up their project directories to test your code.

Thanks for your time reviewing!
